### PR TITLE
[Fixes #130] Update readme with sample data dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,19 @@ Generator has DLMML as a submodule.
 
     # go grab a cup of coffee, it takes an eternity XD
     ```
-5. Place data in the `./DLMML/data` directory.
+5. Place data in the `./data` directory.
+
+    Your data should be divided into classes for classification, for example, if you're classifying "Cats V/s Dogs", then your `./data` directory would look like:
+    ```sh
+    data
+    └───dogs_and_cats
+        ├───test
+        │   ├───cats
+        │   └───dogs
+        └───train
+            ├───cats
+            └───dogs
+    ```
 
 6.  ```sh
     # run the backend 
@@ -88,8 +100,6 @@ Please take a look at our [contributing guidelines](https://github.com/Auto-DL/G
 - Improve the UI and UX.
 
 - Show model training realted stats on the frontend.
-
-- Input form to contain the dataset path and other essential parameters.  
 
 - Visualization and data preprocessing steps.
 


### PR DESCRIPTION

## Pull Request

fixes #130   

### Description
Patch places the output of `tree` linux command in the readme to show the output data dir

### Checklist:
- [x] Followed the guidelines mentioned in our [Contributing document](/CONTRIBUTING.md)
- [x] Ensured that there aren't other open [Pull Requests](https://www.github.com/Auto-DL/Generator/pulls) for the same update/change
- [x] This PR is linked to an [Issue](https://www.github.com/Auto-DL/Generator/issues) and the issue number has been mentioned in the title and body of the PR
- [x] The code is clean and docstrings have been added or updated as required
- [x] Code is linted/formatted locally prior to submission (using `black`)

Signed-off-by: Aditya Srivastava <adityasrivastava301199@gmail.com>

